### PR TITLE
Fix MediaPipe Hands constructor resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { captureResultImage } from "./features/capture/resultCapture";
 export default function App() {
   const [winnerCount, setWinnerCount] = useState(DEFAULT_GAME_CONFIG.winnerCount);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const { stream, error, start, stop } = useCamera();
+  const { stream, error, isStarting, start, stop } = useCamera();
   const { tracked, activeFingers, statusMessage } = useHandTracking(videoRef, stream);
   const { state, countdown, result, reset } = useGameEngine(activeFingers, winnerCount);
   const shareSupported = useMemo(() => supportsFileShare(), []);
@@ -41,7 +41,12 @@ export default function App() {
   return (
     <div className="app-shell">
       {!stream ? (
-        <HomeScreen winnerCount={winnerCount} onWinnerCountChange={setWinnerCount} onStart={start} />
+        <HomeScreen
+          winnerCount={winnerCount}
+          isStarting={isStarting}
+          onWinnerCountChange={setWinnerCount}
+          onStart={start}
+        />
       ) : result ? (
         <ResultScreen
           winnerFingerIds={result.winnerFingerIds}
@@ -63,6 +68,7 @@ export default function App() {
           onExit={handleExit}
         />
       )}
+      {isStarting ? <p className="app-info">카메라 권한을 확인하고 있습니다...</p> : null}
       {error ? <p className="app-error">{error}</p> : null}
     </div>
   );

--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -1,26 +1,32 @@
 type Props = {
   winnerCount: number;
+  isStarting?: boolean;
   onWinnerCountChange: (value: number) => void;
   onStart: () => void;
 };
 
-export function HomeScreen({ winnerCount, onWinnerCountChange, onStart }: Props) {
+export function HomeScreen({ winnerCount, isStarting = false, onWinnerCountChange, onStart }: Props) {
   return (
     <section className="panel home-screen">
       <p className="eyebrow">웹캠 랜덤 게임</p>
       <h1>손가락 뽑기 게임</h1>
       <p>웹캠으로 손가락을 인식해 오늘의 당첨자를 뽑습니다.</p>
       <div className="stepper">
-        <button type="button" aria-label="-" onClick={() => onWinnerCountChange(Math.max(1, winnerCount - 1))}>
+        <button
+          type="button"
+          aria-label="-"
+          disabled={isStarting}
+          onClick={() => onWinnerCountChange(Math.max(1, winnerCount - 1))}
+        >
           -
         </button>
         <span className="stepper-value">{winnerCount}</span>
-        <button type="button" aria-label="+" onClick={() => onWinnerCountChange(winnerCount + 1)}>
+        <button type="button" aria-label="+" disabled={isStarting} onClick={() => onWinnerCountChange(winnerCount + 1)}>
           +
         </button>
       </div>
-      <button type="button" className="primary-button" onClick={onStart}>
-        시작하기
+      <button type="button" className="primary-button" onClick={onStart} disabled={isStarting}>
+        {isStarting ? "카메라 준비 중..." : "시작하기"}
       </button>
     </section>
   );

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -4,14 +4,18 @@ import { requestCameraStream, stopCameraStream } from "../lib/camera";
 export function useCamera() {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
 
   const start = useCallback(async () => {
+    setIsStarting(true);
     try {
       const next = await requestCameraStream();
       setStream(next);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "카메라를 시작할 수 없습니다.");
+    } finally {
+      setIsStarting(false);
     }
   }, []);
 
@@ -22,5 +26,5 @@ export function useCamera() {
 
   useEffect(() => stop, [stop]);
 
-  return { stream, error, start, stop };
+  return { stream, error, isStarting, start, stop };
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,3 +42,8 @@ input {
   color: #ff9abf;
   margin-top: 16px;
 }
+
+.app-info {
+  color: rgba(255, 255, 255, 0.78);
+  margin-top: 16px;
+}

--- a/src/vision/handLandmarks.ts
+++ b/src/vision/handLandmarks.ts
@@ -1,4 +1,4 @@
-import { Hands } from "@mediapipe/hands";
+import * as mpHands from "@mediapipe/hands";
 import type { HandPrediction } from "./fingerDetector";
 
 type MediaPipeResult = {
@@ -6,7 +6,33 @@ type MediaPipeResult = {
   multiHandedness?: Array<{ label?: "Left" | "Right" }>;
 };
 
+type HandsConstructor = new (config: { locateFile: (file: string) => string }) => {
+  setOptions: (options: Record<string, unknown>) => void;
+  onResults: (listener: (results: unknown) => void) => void;
+  send: (payload: { image: HTMLVideoElement }) => Promise<void>;
+  close: () => void;
+};
+
+export function resolveHandsConstructor(moduleObject: Record<string, unknown>): HandsConstructor {
+  if (typeof moduleObject.Hands === "function") {
+    return moduleObject.Hands as HandsConstructor;
+  }
+
+  const defaultExport = moduleObject.default as Record<string, unknown> | undefined;
+  if (defaultExport && typeof defaultExport.Hands === "function") {
+    return defaultExport.Hands as HandsConstructor;
+  }
+
+  const commonJsExport = moduleObject["module.exports"] as Record<string, unknown> | undefined;
+  if (commonJsExport && typeof commonJsExport.Hands === "function") {
+    return commonJsExport.Hands as HandsConstructor;
+  }
+
+  throw new Error("MediaPipe Hands constructor를 찾을 수 없습니다.");
+}
+
 export function createHandsDetector(onPredictions: (predictions: HandPrediction[]) => void) {
+  const Hands = resolveHandsConstructor(mpHands as unknown as Record<string, unknown>);
   const hands = new Hands({
     locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`
   });

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import App from "../../src/App";
+
+vi.mock("../../src/vision/handLandmarks", () => ({
+  createHandsDetector: () => ({
+    send: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn()
+  })
+}));
+
+describe("App start flow", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows camera request feedback immediately after clicking start", async () => {
+    const user = userEvent.setup();
+
+    Object.defineProperty(HTMLMediaElement.prototype, "play", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined)
+    });
+
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({
+        clearRect: vi.fn(),
+        strokeRect: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        stroke: vi.fn()
+      }))
+    });
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(
+          () =>
+            new Promise<MediaStream>((resolve) => {
+              setTimeout(() => resolve({ getTracks: () => [] } as unknown as MediaStream), 50);
+            })
+        )
+      }
+    });
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: /시작하기/i }));
+
+    expect(screen.getByText(/카메라 권한을 확인하고 있습니다/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/손가락을 화면 안에 넣어 주세요/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/HomeScreen.test.tsx
+++ b/tests/components/HomeScreen.test.tsx
@@ -12,6 +12,7 @@ describe("HomeScreen", () => {
     render(
       <HomeScreen
         winnerCount={1}
+        isStarting={false}
         onWinnerCountChange={onWinnerCountChange}
         onStart={onStart}
       />

--- a/tests/vision/handLandmarks.test.ts
+++ b/tests/vision/handLandmarks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveHandsConstructor } from "../../src/vision/handLandmarks";
+
+describe("resolveHandsConstructor", () => {
+  it("returns direct Hands export when available", () => {
+    const Hands = class {};
+    expect(resolveHandsConstructor({ Hands })).toBe(Hands);
+  });
+
+  it("returns Hands from default wrapper export", () => {
+    const Hands = class {};
+    expect(resolveHandsConstructor({ default: { Hands } })).toBe(Hands);
+  });
+
+  it("returns Hands from module.exports wrapper export", () => {
+    const Hands = class {};
+    expect(resolveHandsConstructor({ "module.exports": { Hands } })).toBe(Hands);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve `@mediapipe/hands` constructor across browser bundle export shapes
- add regression tests for direct/default/commonjs wrapper module shapes

## Root cause
The browser bundle was not exposing `Hands` as a direct named constructor, so `new Hands(...)` failed at runtime with `pm.Hands is not a constructor`.

## Testing
- npm test
- npm run build