### PR TITLE
fix: resolve MediaPipe Hands from global scope

### DIFF
--- a/src/vision/handLandmarks.ts
+++ b/src/vision/handLandmarks.ts
@@ -13,6 +13,15 @@ type HandsConstructor = new (config: { locateFile: (file: string) => string }) =
   close: () => void;
 };
 
+function resolveGlobalHandsConstructor(): HandsConstructor | null {
+  const globalScope = globalThis as Record<string, unknown> | undefined;
+  if (globalScope && typeof globalScope.Hands === "function") {
+    return globalScope.Hands as HandsConstructor;
+  }
+
+  return null;
+}
+
 export function resolveHandsConstructor(moduleObject: Record<string, unknown>): HandsConstructor {
   if (typeof moduleObject.Hands === "function") {
     return moduleObject.Hands as HandsConstructor;
@@ -26,6 +35,11 @@ export function resolveHandsConstructor(moduleObject: Record<string, unknown>): 
   const commonJsExport = moduleObject["module.exports"] as Record<string, unknown> | undefined;
   if (commonJsExport && typeof commonJsExport.Hands === "function") {
     return commonJsExport.Hands as HandsConstructor;
+  }
+
+  const globalHands = resolveGlobalHandsConstructor();
+  if (globalHands) {
+    return globalHands;
   }
 
   throw new Error("MediaPipe Hands constructor를 찾을 수 없습니다.");

--- a/tests/vision/handLandmarks.test.ts
+++ b/tests/vision/handLandmarks.test.ts
@@ -16,4 +16,20 @@ describe("resolveHandsConstructor", () => {
     const Hands = class {};
     expect(resolveHandsConstructor({ "module.exports": { Hands } })).toBe(Hands);
   });
+
+  it("falls back to the global Hands constructor when the bundle registers it globally", () => {
+    const previousHands = (globalThis as Record<string, unknown>).Hands;
+    const Hands = class {};
+    (globalThis as Record<string, unknown>).Hands = Hands;
+
+    try {
+      expect(resolveHandsConstructor({})).toBe(Hands);
+    } finally {
+      if (previousHands === undefined) {
+        delete (globalThis as Record<string, unknown>).Hands;
+      } else {
+        (globalThis as Record<string, unknown>).Hands = previousHands;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary\n- fix the deployed MediaPipe resolver by falling back to the global  constructor used by the browser bundle\n- add a regression test for the global-scope registration path\n\n## Testing\n- npm test\n- npm run build\n\nCloses #5