### PR TITLE
fix: handle interrupted camera play requests

### DIFF
--- a/src/components/camera/CameraScreen.tsx
+++ b/src/components/camera/CameraScreen.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import type { RefObject } from "react";
 import type { TrackedFinger } from "../../types/game";
 import { CameraCanvas } from "./CameraCanvas";
@@ -25,13 +24,6 @@ export function CameraScreen({
   countdown,
   onExit
 }: Props) {
-  useEffect(() => {
-    if (videoRef.current) {
-      videoRef.current.srcObject = stream;
-      void videoRef.current.play();
-    }
-  }, [stream, videoRef]);
-
   return (
     <section className="camera-layout">
       <div className="camera-header">

--- a/src/hooks/useHandTracking.ts
+++ b/src/hooks/useHandTracking.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { DEFAULT_GAME_CONFIG } from "../config/gameConfig";
+import { attachStreamToVideo } from "../lib/camera";
 import type { TrackedFinger } from "../types/game";
 import { getFingerCandidates, type HandPrediction } from "../vision/fingerDetector";
 import { reconcileTrackedFingers } from "../vision/fingerTracker";
@@ -15,8 +16,7 @@ export function useHandTracking(videoRef: RefObject<HTMLVideoElement>, stream: M
   useEffect(() => {
     const video = videoRef.current;
     if (!video || !stream) return;
-    video.srcObject = stream;
-    void video.play();
+    void attachStreamToVideo(video, stream);
   }, [stream, videoRef]);
 
   useEffect(() => {

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -9,6 +9,25 @@ export async function requestCameraStream(): Promise<MediaStream> {
   });
 }
 
+export async function attachStreamToVideo(
+  video: HTMLVideoElement,
+  stream: MediaStream
+): Promise<void> {
+  if (video.srcObject !== stream) {
+    video.srcObject = stream;
+  }
+
+  try {
+    await video.play();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return;
+    }
+
+    throw error;
+  }
+}
+
 export function stopCameraStream(stream: MediaStream | null) {
   stream?.getTracks().forEach((track) => track.stop());
 }

--- a/tests/lib/camera.test.ts
+++ b/tests/lib/camera.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachStreamToVideo } from "../../src/lib/camera";
+
+describe("attachStreamToVideo", () => {
+  it("ignores AbortError raised by an interrupted play request", async () => {
+    const stream = {} as MediaStream;
+    const video = document.createElement("video");
+    const play = vi.fn().mockRejectedValue(new DOMException("interrupted", "AbortError"));
+    Object.defineProperty(video, "play", {
+      value: play,
+      configurable: true
+    });
+
+    await expect(attachStreamToVideo(video, stream)).resolves.toBeUndefined();
+    expect(video.srcObject).toBe(stream);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-AbortError failures from play", async () => {
+    const stream = {} as MediaStream;
+    const video = document.createElement("video");
+    const play = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(video, "play", {
+      value: play,
+      configurable: true
+    });
+
+    await expect(attachStreamToVideo(video, stream)).rejects.toThrow("permission denied");
+  });
+});


### PR DESCRIPTION
## Summary
- stop calling video.play from two different places during camera startup
- centralize stream attachment and ignore AbortError from interrupted play requests
- add regression tests for interrupted and non-interrupted play failures

## Testing
- npm test
- npm run build

Closes #7