### PR TITLE
fix: show camera permission guidance while starting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { captureResultImage } from "./features/capture/resultCapture";
 export default function App() {
   const [winnerCount, setWinnerCount] = useState(DEFAULT_GAME_CONFIG.winnerCount);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const { stream, error, isStarting, start, stop } = useCamera();
+  const { stream, error, isStarting, permissionHint, start, stop } = useCamera();
   const { tracked, activeFingers, statusMessage } = useHandTracking(videoRef, stream);
   const { state, countdown, result, reset } = useGameEngine(activeFingers, winnerCount);
   const shareSupported = useMemo(() => supportsFileShare(), []);
@@ -69,6 +69,7 @@ export default function App() {
         />
       )}
       {isStarting ? <p className="app-info">카메라 권한을 확인하고 있습니다...</p> : null}
+      {permissionHint ? <p className="app-info">{permissionHint}</p> : null}
       {error ? <p className="app-error">{error}</p> : null}
     </div>
   );

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -1,30 +1,53 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { requestCameraStream, stopCameraStream } from "../lib/camera";
+
+const ADDRESS_BAR_PERMISSION_HINT_DELAY_MS = 2000;
 
 export function useCamera() {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(false);
+  const [permissionHint, setPermissionHint] = useState<string | null>(null);
+  const hintTimerRef = useRef<number | null>(null);
+
+  const clearPermissionHintTimer = useCallback(() => {
+    if (hintTimerRef.current !== null) {
+      window.clearTimeout(hintTimerRef.current);
+      hintTimerRef.current = null;
+    }
+  }, []);
 
   const start = useCallback(async () => {
     setIsStarting(true);
+    setError(null);
+    setPermissionHint("카메라 권한 요청을 확인해 주세요.");
+    clearPermissionHintTimer();
+    hintTimerRef.current = window.setTimeout(() => {
+      setPermissionHint("주소창의 카메라 아이콘을 눌러 접근을 허용해 주세요.");
+    }, ADDRESS_BAR_PERMISSION_HINT_DELAY_MS);
+
     try {
       const next = await requestCameraStream();
       setStream(next);
       setError(null);
+      setPermissionHint(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "카메라를 시작할 수 없습니다.");
+      setPermissionHint(null);
     } finally {
+      clearPermissionHintTimer();
       setIsStarting(false);
     }
-  }, []);
+  }, [clearPermissionHintTimer]);
 
   const stop = useCallback(() => {
     stopCameraStream(stream);
     setStream(null);
-  }, [stream]);
+    setPermissionHint(null);
+    clearPermissionHintTimer();
+  }, [clearPermissionHintTimer, stream]);
 
   useEffect(() => stop, [stop]);
 
-  return { stream, error, isStarting, start, stop };
+  return { stream, error, isStarting, permissionHint, start, stop };
 }

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../src/App";
 
@@ -12,12 +11,11 @@ vi.mock("../../src/vision/handLandmarks", () => ({
 
 describe("App start flow", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it("shows camera request feedback immediately after clicking start", async () => {
-    const user = userEvent.setup();
-
     Object.defineProperty(HTMLMediaElement.prototype, "play", {
       configurable: true,
       value: vi.fn().mockResolvedValue(undefined)
@@ -47,12 +45,35 @@ describe("App start flow", () => {
     });
 
     render(<App />);
-    await user.click(screen.getByRole("button", { name: /시작하기/i }));
+    fireEvent.click(screen.getByRole("button", { name: /시작하기/i }));
 
     expect(screen.getByText(/카메라 권한을 확인하고 있습니다/i)).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText(/손가락을 화면 안에 넣어 주세요/i)).toBeInTheDocument();
     });
+  });
+
+  it("shows permission guidance when the camera request stays pending", async () => {
+    vi.useFakeTimers();
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(() => new Promise<MediaStream>(() => undefined))
+      }
+    });
+
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: /시작하기/i }));
+
+    expect(screen.getByRole("button", { name: /카메라 준비 중/i })).toBeDisabled();
+    expect(screen.getByText(/카메라 권한을 확인하고 있습니다/i)).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText(/주소창의 카메라 아이콘을 눌러 접근을 허용/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show immediate camera permission feedback when the user clicks 시작하기
- keep a visible hint while getUserMedia stays pending
- after a short delay, instruct the user to use the address-bar camera icon
- add regression coverage for pending permission requests

## Testing
- npm test
- npm run build

Closes #9