### PR TITLE
fix: move camera startup into dedicated permission screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { HomeScreen } from "./components/home/HomeScreen";
+import { CameraPermissionScreen } from "./components/home/CameraPermissionScreen";
 import { CameraScreen } from "./components/camera/CameraScreen";
 import { ResultScreen } from "./components/result/ResultScreen";
 import { DEFAULT_GAME_CONFIG } from "./config/gameConfig";
@@ -11,11 +12,19 @@ import { captureResultImage } from "./features/capture/resultCapture";
 
 export default function App() {
   const [winnerCount, setWinnerCount] = useState(DEFAULT_GAME_CONFIG.winnerCount);
+  const [isPreparingCamera, setIsPreparingCamera] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const { stream, error, isStarting, permissionHint, start, stop } = useCamera();
   const { tracked, activeFingers, statusMessage } = useHandTracking(videoRef, stream);
   const { state, countdown, result, reset } = useGameEngine(activeFingers, winnerCount);
   const shareSupported = useMemo(() => supportsFileShare(), []);
+  const showPermissionScreen = !stream && isPreparingCamera;
+
+  useEffect(() => {
+    if (stream) {
+      setIsPreparingCamera(false);
+    }
+  }, [stream]);
 
   async function handleDownload() {
     if (!videoRef.current || !result) return;
@@ -36,16 +45,40 @@ export default function App() {
   function handleExit() {
     stop();
     reset();
+    setIsPreparingCamera(false);
+  }
+
+  function handleStart() {
+    setIsPreparingCamera(true);
+    void start();
+  }
+
+  function handleRetryCamera() {
+    void start();
+  }
+
+  function handleBackHome() {
+    stop();
+    reset();
+    setIsPreparingCamera(false);
   }
 
   return (
     <div className="app-shell">
-      {!stream ? (
+      {showPermissionScreen ? (
+        <CameraPermissionScreen
+          isStarting={isStarting}
+          permissionHint={permissionHint}
+          error={error}
+          onRetry={handleRetryCamera}
+          onBack={handleBackHome}
+        />
+      ) : !stream ? (
         <HomeScreen
           winnerCount={winnerCount}
           isStarting={isStarting}
           onWinnerCountChange={setWinnerCount}
-          onStart={start}
+          onStart={handleStart}
         />
       ) : result ? (
         <ResultScreen
@@ -68,9 +101,9 @@ export default function App() {
           onExit={handleExit}
         />
       )}
-      {isStarting ? <p className="app-info">카메라 권한을 확인하고 있습니다...</p> : null}
-      {permissionHint ? <p className="app-info">{permissionHint}</p> : null}
-      {error ? <p className="app-error">{error}</p> : null}
+      {!showPermissionScreen && isStarting ? <p className="app-info">카메라 권한을 확인하고 있습니다...</p> : null}
+      {!showPermissionScreen && permissionHint ? <p className="app-info">{permissionHint}</p> : null}
+      {!showPermissionScreen && error ? <p className="app-error">{error}</p> : null}
     </div>
   );
 }

--- a/src/components/home/CameraPermissionScreen.tsx
+++ b/src/components/home/CameraPermissionScreen.tsx
@@ -1,0 +1,40 @@
+type Props = {
+  isStarting: boolean;
+  permissionHint: string | null;
+  error: string | null;
+  onRetry: () => void;
+  onBack: () => void;
+};
+
+export function CameraPermissionScreen({
+  isStarting,
+  permissionHint,
+  error,
+  onRetry,
+  onBack
+}: Props) {
+  const message = error ?? permissionHint ?? "카메라 권한을 확인하고 있습니다...";
+
+  return (
+    <section className="panel permission-screen">
+      <p className="eyebrow">웹캠 연결</p>
+      <h1>카메라 연결 준비</h1>
+      <p>
+        브라우저가 카메라 접근 권한을 확인하는 중입니다. 팝업이 보이지 않으면 주소창의 카메라 아이콘을
+        눌러 허용해 주세요.
+      </p>
+      <div className="permission-status">
+        <strong>{isStarting ? "카메라 권한을 확인하고 있습니다..." : "카메라 연결을 다시 확인해 주세요."}</strong>
+        <p>{message}</p>
+      </div>
+      <div className="result-actions">
+        <button type="button" className="primary-button" onClick={onRetry} disabled={isStarting}>
+          {isStarting ? "카메라 요청 중..." : "다시 요청"}
+        </button>
+        <button type="button" className="ghost-button" onClick={onBack}>
+          처음으로
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,10 +1,12 @@
 .home-screen,
+.permission-screen,
 .result-screen {
   display: grid;
   gap: 18px;
 }
 
 .home-screen h1,
+.permission-screen h1,
 .result-screen h2 {
   margin: 0;
   font-size: clamp(2.4rem, 5vw, 4.5rem);
@@ -56,6 +58,19 @@
   text-align: center;
   font-size: 2rem;
   font-weight: 700;
+}
+
+.permission-status {
+  display: grid;
+  gap: 8px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.permission-status p,
+.permission-status strong {
+  margin: 0;
 }
 
 .camera-layout {

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -47,7 +47,9 @@ describe("App start flow", () => {
     render(<App />);
     fireEvent.click(screen.getByRole("button", { name: /시작하기/i }));
 
+    expect(screen.getByRole("heading", { name: /카메라 연결 준비/i })).toBeInTheDocument();
     expect(screen.getByText(/카메라 권한을 확인하고 있습니다/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /카메라 요청 중/i })).toBeDisabled();
 
     await waitFor(() => {
       expect(screen.getByText(/손가락을 화면 안에 넣어 주세요/i)).toBeInTheDocument();
@@ -67,7 +69,8 @@ describe("App start flow", () => {
     render(<App />);
     fireEvent.click(screen.getByRole("button", { name: /시작하기/i }));
 
-    expect(screen.getByRole("button", { name: /카메라 준비 중/i })).toBeDisabled();
+    expect(screen.getByRole("heading", { name: /카메라 연결 준비/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /카메라 요청 중/i })).toBeDisabled();
     expect(screen.getByText(/카메라 권한을 확인하고 있습니다/i)).toBeInTheDocument();
 
     await act(async () => {
@@ -75,5 +78,7 @@ describe("App start flow", () => {
     });
 
     expect(screen.getByText(/주소창의 카메라 아이콘을 눌러 접근을 허용/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /카메라 요청 중/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /처음으로/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- move camera startup into a dedicated permission screen so the app reacts immediately after clicking 시작하기
- keep camera permission guidance visible while getUserMedia is pending
- give users an explicit way to return to the home screen instead of appearing stuck

## Testing
- npm test
- npm run build

Closes #9