### PR TITLE
feat: show winning fingers and result preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { HomeScreen } from "./components/home/HomeScreen";
 import { CameraPermissionScreen } from "./components/home/CameraPermissionScreen";
 import { CameraScreen } from "./components/camera/CameraScreen";
@@ -9,16 +9,54 @@ import { useHandTracking } from "./hooks/useHandTracking";
 import { useGameEngine } from "./hooks/useGameEngine";
 import { downloadBlob, shareBlob, supportsFileShare } from "./lib/share";
 import { captureResultImage } from "./features/capture/resultCapture";
+import type { TrackedFinger } from "./types/game";
 
 export default function App() {
   const [winnerCount, setWinnerCount] = useState(DEFAULT_GAME_CONFIG.winnerCount);
   const [isPreparingCamera, setIsPreparingCamera] = useState(false);
+  const [resultImageBlob, setResultImageBlob] = useState<Blob | null>(null);
+  const [resultImageUrl, setResultImageUrl] = useState<string | null>(null);
+  const [resultWinnerFingers, setResultWinnerFingers] = useState<TrackedFinger[]>([]);
   const videoRef = useRef<HTMLVideoElement>(null);
   const { stream, error, isStarting, permissionHint, start, stop } = useCamera();
   const { tracked, activeFingers, statusMessage } = useHandTracking(videoRef, stream);
-  const { state, countdown, result, reset } = useGameEngine(activeFingers, winnerCount);
   const shareSupported = useMemo(() => supportsFileShare(), []);
   const showPermissionScreen = !stream && isPreparingCamera;
+
+  const clearResultPreview = useCallback(() => {
+    setResultImageBlob(null);
+    setResultWinnerFingers([]);
+    setResultImageUrl((currentUrl) => {
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+      }
+      return null;
+    });
+  }, []);
+
+  const handleDrawResult = useCallback(
+    (winnerFingerIds: string[], winnerFingers: TrackedFinger[]) => {
+      const video = videoRef.current;
+      setResultWinnerFingers(winnerFingers);
+      if (!video) return;
+
+      void captureResultImage(video, tracked, winnerFingerIds, winnerCount).then((blob) => {
+        const nextUrl = URL.createObjectURL(blob);
+        setResultImageBlob(blob);
+        setResultImageUrl((currentUrl) => {
+          if (currentUrl) {
+            URL.revokeObjectURL(currentUrl);
+          }
+          return nextUrl;
+        });
+      });
+    },
+    [tracked, winnerCount]
+  );
+
+  const { state, countdown, result, reset } = useGameEngine(activeFingers, winnerCount, handleDrawResult);
+
+  useEffect(() => clearResultPreview, [clearResultPreview]);
 
   useEffect(() => {
     if (stream) {
@@ -27,23 +65,27 @@ export default function App() {
   }, [stream]);
 
   async function handleDownload() {
-    if (!videoRef.current || !result) return;
-    const blob = await captureResultImage(videoRef.current, tracked, result.winnerFingerIds, winnerCount);
-    downloadBlob(blob, `finger-lottery-result-${Date.now()}.png`);
+    if (!result) return;
+    if (resultImageBlob) {
+      downloadBlob(resultImageBlob, `finger-lottery-result-${Date.now()}.png`);
+    }
   }
 
   async function handleShare() {
-    if (!videoRef.current || !result) return;
-    const blob = await captureResultImage(videoRef.current, tracked, result.winnerFingerIds, winnerCount);
-    await shareBlob(blob, `finger-lottery-result-${Date.now()}.png`);
+    if (!result) return;
+    if (resultImageBlob) {
+      await shareBlob(resultImageBlob, `finger-lottery-result-${Date.now()}.png`);
+    }
   }
 
   function handleRestart() {
+    clearResultPreview();
     reset();
   }
 
   function handleExit() {
     stop();
+    clearResultPreview();
     reset();
     setIsPreparingCamera(false);
   }
@@ -59,6 +101,7 @@ export default function App() {
 
   function handleBackHome() {
     stop();
+    clearResultPreview();
     reset();
     setIsPreparingCamera(false);
   }
@@ -83,6 +126,8 @@ export default function App() {
       ) : result ? (
         <ResultScreen
           winnerFingerIds={result.winnerFingerIds}
+          winnerFingers={resultWinnerFingers}
+          resultImageUrl={resultImageUrl}
           onRestart={handleRestart}
           onDownload={handleDownload}
           onShare={handleShare}

--- a/src/components/result/ResultScreen.tsx
+++ b/src/components/result/ResultScreen.tsx
@@ -1,5 +1,9 @@
+import type { TrackedFinger } from "../../types/game";
+
 type Props = {
   winnerFingerIds: string[];
+  winnerFingers: TrackedFinger[];
+  resultImageUrl: string | null;
   onRestart: () => void;
   onDownload: () => void;
   onShare: () => void;
@@ -9,6 +13,8 @@ type Props = {
 
 export function ResultScreen({
   winnerFingerIds,
+  winnerFingers,
+  resultImageUrl,
   onRestart,
   onDownload,
   onShare,
@@ -18,7 +24,31 @@ export function ResultScreen({
   return (
     <section className="panel result-screen">
       <h2>당첨!</h2>
-      <p>당첨 손가락 수: {winnerFingerIds.length}</p>
+      <p>노란색으로 표시된 손가락이 당첨입니다.</p>
+      {resultImageUrl ? (
+        <figure className="result-preview">
+          <img src={resultImageUrl} alt="당첨 결과 사진" />
+          <figcaption>당첨 손가락이 원형 테두리와 번호로 표시됩니다.</figcaption>
+        </figure>
+      ) : (
+        <div className="result-preview-placeholder">결과 사진을 만드는 중입니다...</div>
+      )}
+      <ol className="winner-list" aria-label="당첨 손가락 목록">
+        {winnerFingers.map((finger, index) => (
+          <li key={finger.fingerId}>
+            <strong>{index + 1}번 손가락</strong>
+            <span>{getFingerTypeLabel(finger.fingerType)}</span>
+          </li>
+        ))}
+        {winnerFingers.length === 0
+          ? winnerFingerIds.map((fingerId, index) => (
+              <li key={fingerId}>
+                <strong>{index + 1}번 손가락</strong>
+                <span>식별 정보 없음</span>
+              </li>
+            ))
+          : null}
+      </ol>
       <div className="result-actions">
         <button type="button" className="secondary-button" onClick={onRestart}>
         다시하기
@@ -39,4 +69,15 @@ export function ResultScreen({
       </div>
     </section>
   );
+}
+
+function getFingerTypeLabel(fingerType: TrackedFinger["fingerType"]) {
+  const labels: Record<TrackedFinger["fingerType"], string> = {
+    thumb: "엄지",
+    index: "검지",
+    middle: "중지",
+    ring: "약지",
+    pinky: "새끼"
+  };
+  return labels[fingerType];
 }

--- a/src/features/result/resultOverlay.ts
+++ b/src/features/result/resultOverlay.ts
@@ -11,6 +11,8 @@ export function drawResultOverlay(
   ctx.fillStyle = "rgba(14, 7, 24, 0.26)";
   ctx.fillRect(0, 0, width, height);
 
+  let winnerIndex = 0;
+
   fingers.forEach((finger) => {
     const isWinner = winnerFingerIds.includes(finger.fingerId);
     const x = finger.x * width;
@@ -20,6 +22,21 @@ export function drawResultOverlay(
     ctx.strokeStyle = isWinner ? "#ffe95b" : "rgba(255,255,255,0.5)";
     ctx.lineWidth = isWinner ? 8 : 4;
     ctx.stroke();
+
+    if (isWinner) {
+      winnerIndex += 1;
+      ctx.fillStyle = "#ffe95b";
+      ctx.beginPath();
+      ctx.arc(x + 38, y - 38, 26, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#12091f";
+      ctx.font = "700 28px sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(String(winnerIndex), x + 38, y - 38);
+      ctx.textAlign = "start";
+      ctx.textBaseline = "alphabetic";
+    }
   });
 
   ctx.fillStyle = "#ffffff";

--- a/src/hooks/useGameEngine.ts
+++ b/src/hooks/useGameEngine.ts
@@ -6,7 +6,11 @@ import type { DrawResult, GameState, TrackedFinger } from "../types/game";
 import { pickUniqueRandomItems } from "../utils/random";
 import { isStableForDuration } from "../utils/time";
 
-export function useGameEngine(activeFingers: TrackedFinger[], winnerCount: number) {
+export function useGameEngine(
+  activeFingers: TrackedFinger[],
+  winnerCount: number,
+  onDrawResult?: (winnerFingerIds: string[], winnerFingers: TrackedFinger[]) => void
+) {
   const [state, setState] = useState<GameState>("camera_ready");
   const [stableSince, setStableSince] = useState<number | null>(null);
   const [countdownStart, setCountdownStart] = useState<number | null>(null);
@@ -53,6 +57,8 @@ export function useGameEngine(activeFingers: TrackedFinger[], winnerCount: numbe
       }
       if (nextState === "drawing") {
         const winnerFingerIds = pickUniqueRandomItems(activeFingerIds, Math.min(winnerCount, activeFingerIds.length));
+        const winnerFingers = activeFingers.filter((finger) => winnerFingerIds.includes(finger.fingerId));
+        onDrawResult?.(winnerFingerIds, winnerFingers);
         setResult({
           winnerFingerIds,
           capturedAt: Date.now()
@@ -62,7 +68,7 @@ export function useGameEngine(activeFingers: TrackedFinger[], winnerCount: numbe
     }
 
     previousFingerIds.current = activeFingerIds;
-  }, [activeFingerIds, countdown, countdownStart, isStable, state, winnerCount]);
+  }, [activeFingerIds, activeFingers, countdown, countdownStart, isStable, onDrawResult, state, winnerCount]);
 
   function reset() {
     setStableSince(null);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -131,3 +131,55 @@
   flex-wrap: wrap;
   gap: 12px;
 }
+
+.result-preview {
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.result-preview img,
+.result-preview-placeholder {
+  width: 100%;
+  min-height: 280px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.result-preview img {
+  display: block;
+  object-fit: cover;
+}
+
+.result-preview figcaption {
+  color: var(--text-sub);
+}
+
+.result-preview-placeholder {
+  display: grid;
+  place-items: center;
+  color: var(--text-sub);
+}
+
+.winner-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.winner-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 233, 91, 0.14);
+  color: var(--text-main);
+}
+
+.winner-list strong {
+  color: var(--accent-2);
+}

--- a/tests/components/ResultScreen.test.tsx
+++ b/tests/components/ResultScreen.test.tsx
@@ -3,10 +3,24 @@ import { describe, expect, it } from "vitest";
 import { ResultScreen } from "../../src/components/result/ResultScreen";
 
 describe("ResultScreen", () => {
-  it("renders result actions", () => {
+  it("renders winner fingers, result image, and actions", () => {
     render(
       <ResultScreen
         winnerFingerIds={["f1"]}
+        winnerFingers={[
+          {
+            fingerId: "f1",
+            handTrackId: "Right-0",
+            fingerType: "index",
+            x: 0.5,
+            y: 0.4,
+            confidence: 0.9,
+            stableFrames: 3,
+            missingFrames: 0,
+            status: "active"
+          }
+        ]}
+        resultImageUrl="blob:result-preview"
         onRestart={() => {}}
         onDownload={() => {}}
         onShare={() => {}}
@@ -14,6 +28,9 @@ describe("ResultScreen", () => {
       />
     );
 
+    expect(screen.getByRole("img", { name: /당첨 결과 사진/i })).toHaveAttribute("src", "blob:result-preview");
+    expect(screen.getByText(/1번 손가락/i)).toBeInTheDocument();
+    expect(screen.getByText(/검지/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /다시하기/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /다운로드/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /공유/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- capture the result image at the moment winners are drawn
- show the captured result photo in the result screen
- list the winning fingers with readable finger labels
- draw numbered winner badges on the saved/shared result image

## Testing
- npm test
- npm run build

Closes #14