### PR TITLE
feat: track only index fingers

### DIFF
--- a/src/components/camera/RecognitionHud.tsx
+++ b/src/components/camera/RecognitionHud.tsx
@@ -9,7 +9,7 @@ export function RecognitionHud({ activeCount, winnerCount, message, countdown }:
   return (
     <div className="panel recognition-hud">
       <div className="recognition-meta">
-        <span>인식된 손가락 {activeCount}</span>
+        <span>인식된 검지 {activeCount}</span>
         <span>당첨 인원 {winnerCount}</span>
       </div>
       <p>{message}</p>

--- a/src/components/home/HomeScreen.tsx
+++ b/src/components/home/HomeScreen.tsx
@@ -9,8 +9,8 @@ export function HomeScreen({ winnerCount, isStarting = false, onWinnerCountChang
   return (
     <section className="panel home-screen">
       <p className="eyebrow">웹캠 랜덤 게임</p>
-      <h1>손가락 뽑기 게임</h1>
-      <p>웹캠으로 손가락을 인식해 오늘의 당첨자를 뽑습니다.</p>
+      <h1>검지 뽑기 게임</h1>
+      <p>웹캠으로 참여자의 검지를 인식해 오늘의 당첨자를 뽑습니다.</p>
       <div className="stepper">
         <button
           type="button"

--- a/src/components/result/ResultScreen.tsx
+++ b/src/components/result/ResultScreen.tsx
@@ -24,26 +24,26 @@ export function ResultScreen({
   return (
     <section className="panel result-screen">
       <h2>당첨!</h2>
-      <p>노란색으로 표시된 손가락이 당첨입니다.</p>
+      <p>노란색으로 표시된 검지가 당첨입니다.</p>
       {resultImageUrl ? (
         <figure className="result-preview">
           <img src={resultImageUrl} alt="당첨 결과 사진" />
-          <figcaption>당첨 손가락이 원형 테두리와 번호로 표시됩니다.</figcaption>
+          <figcaption>당첨 검지가 원형 테두리와 번호로 표시됩니다.</figcaption>
         </figure>
       ) : (
         <div className="result-preview-placeholder">결과 사진을 만드는 중입니다...</div>
       )}
-      <ol className="winner-list" aria-label="당첨 손가락 목록">
+      <ol className="winner-list" aria-label="당첨 검지 목록">
         {winnerFingers.map((finger, index) => (
           <li key={finger.fingerId}>
-            <strong>{index + 1}번 손가락</strong>
+            <strong>{index + 1}번 검지</strong>
             <span>{getFingerTypeLabel(finger.fingerType)}</span>
           </li>
         ))}
         {winnerFingers.length === 0
           ? winnerFingerIds.map((fingerId, index) => (
               <li key={fingerId}>
-                <strong>{index + 1}번 손가락</strong>
+                <strong>{index + 1}번 검지</strong>
                 <span>식별 정보 없음</span>
               </li>
             ))

--- a/src/hooks/useHandTracking.ts
+++ b/src/hooks/useHandTracking.ts
@@ -9,7 +9,7 @@ import { createHandsDetector } from "../vision/handLandmarks";
 
 export function useHandTracking(videoRef: RefObject<HTMLVideoElement>, stream: MediaStream | null) {
   const [tracked, setTracked] = useState<TrackedFinger[]>([]);
-  const [statusMessage, setStatusMessage] = useState("손가락을 화면 안에 넣어 주세요");
+  const [statusMessage, setStatusMessage] = useState("검지를 화면 안에 넣어 주세요");
   const detectorRef = useRef<Awaited<ReturnType<typeof createHandsDetector>> | null>(null);
   const animationFrameRef = useRef<number | null>(null);
 
@@ -64,9 +64,9 @@ export function useHandTracking(videoRef: RefObject<HTMLVideoElement>, stream: M
 
   useEffect(() => {
     if (activeFingers.length === 0) {
-      setStatusMessage("손가락을 화면 안에 넣어 주세요");
+      setStatusMessage("검지를 화면 안에 넣어 주세요");
     } else if (activeFingers.length < DEFAULT_GAME_CONFIG.winnerCount) {
-      setStatusMessage("당첨 인원 수보다 많은 손가락이 필요합니다");
+      setStatusMessage("당첨 인원 수보다 많은 검지가 필요합니다");
     } else {
       setStatusMessage("잠시 그대로 유지해 주세요");
     }

--- a/src/vision/fingerDetector.ts
+++ b/src/vision/fingerDetector.ts
@@ -1,4 +1,4 @@
-import type { FingerType, TrackedFinger } from "../types/game";
+import type { FingerType } from "../types/game";
 
 export type Landmark = { x: number; y: number; z: number };
 
@@ -16,13 +16,7 @@ export type FingerCandidate = {
   confidence: number;
 };
 
-const FINGER_TIPS: Record<FingerType, number> = {
-  thumb: 4,
-  index: 8,
-  middle: 12,
-  ring: 16,
-  pinky: 20
-};
+const INDEX_FINGER_TIP_INDEX = 8;
 
 function inPlayArea(x: number, y: number) {
   return x > 0.15 && x < 0.85 && y > 0.1 && y < 0.9;
@@ -32,17 +26,15 @@ export function getFingerCandidates(predictions: HandPrediction[]): FingerCandid
   return predictions.flatMap((hand, handIndex) => {
     if (hand.confidence < 0.55) return [];
 
-    return Object.entries(FINGER_TIPS)
-      .map(([fingerType, landmarkIndex]) => {
-        const point = hand.landmarks[landmarkIndex];
-        return {
-          handTrackId: `${hand.handedness}-${handIndex}`,
-          fingerType: fingerType as TrackedFinger["fingerType"],
-          x: point?.x ?? 0,
-          y: point?.y ?? 0,
-          confidence: hand.confidence
-        };
-      })
-      .filter((candidate) => inPlayArea(candidate.x, candidate.y));
+    const point = hand.landmarks[INDEX_FINGER_TIP_INDEX];
+    const candidate = {
+      handTrackId: `${hand.handedness}-${handIndex}`,
+      fingerType: "index" as FingerType,
+      x: point?.x ?? 0,
+      y: point?.y ?? 0,
+      confidence: hand.confidence
+    };
+
+    return inPlayArea(candidate.x, candidate.y) ? [candidate] : [];
   });
 }

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -54,7 +54,7 @@ describe("App start flow", () => {
     expect(screen.getByRole("button", { name: /카메라 요청 중/i })).toBeDisabled();
 
     await waitFor(() => {
-      expect(screen.getByText(/손가락을 화면 안에 넣어 주세요/i)).toBeInTheDocument();
+      expect(screen.getByText(/검지를 화면 안에 넣어 주세요/i)).toBeInTheDocument();
     });
     expect(stopTrack).not.toHaveBeenCalled();
   });

--- a/tests/components/ResultScreen.test.tsx
+++ b/tests/components/ResultScreen.test.tsx
@@ -29,8 +29,7 @@ describe("ResultScreen", () => {
     );
 
     expect(screen.getByRole("img", { name: /당첨 결과 사진/i })).toHaveAttribute("src", "blob:result-preview");
-    expect(screen.getByText(/1번 손가락/i)).toBeInTheDocument();
-    expect(screen.getByText(/검지/i)).toBeInTheDocument();
+    expect(screen.getByText(/1번 검지/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /다시하기/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /다운로드/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /공유/i })).toBeInTheDocument();

--- a/tests/vision/fingerDetector.test.ts
+++ b/tests/vision/fingerDetector.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getFingerCandidates, type Landmark } from "../../src/vision/fingerDetector";
+
+function landmarksWithVisibleFingerTips(): Landmark[] {
+  return Array.from({ length: 21 }, (_, index) => ({
+    x: 0.2 + index * 0.01,
+    y: 0.2 + index * 0.01,
+    z: 0
+  }));
+}
+
+describe("getFingerCandidates", () => {
+  it("tracks only the index finger tip for each detected hand", () => {
+    const candidates = getFingerCandidates([
+      {
+        handedness: "Right",
+        confidence: 0.9,
+        landmarks: landmarksWithVisibleFingerTips()
+      }
+    ]);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      handTrackId: "Right-0",
+      fingerType: "index",
+      x: 0.28,
+      y: 0.28
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- track only index fingertip landmark 8 for each detected hand
- prevent thumb/middle/ring/pinky from becoming lottery candidates
- update camera/home/result copy to use 검지 language
- add regression coverage for one index candidate per hand

## Testing
- npm test
- npm run build
